### PR TITLE
sudo error acme.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ee-acme-sh
+# wo-acme-sh
 
-## Bash script to install Let's Encrypt SSL certificates automatically using acme.sh on servers running with EasyEngine
+## Bash script to install Let's Encrypt SSL certificates automatically using acme.sh on servers running with WordOps, developed by [Virtubox](https://virtubox.net) for EasyEngine and forked to WordOps.
 
 ![ee-acme-sh](https://raw.githubusercontent.com/VirtuBox/ee-acme-sh/master/ee-acme.png)
 


### PR DESCRIPTION
If I want to renew SSL with acme-sh and I don't have sudo acces I recieve this error.
Error removing txt for domain:_acme-c

I solved the problem with manual modify the sudo commands in wo-acme.sh